### PR TITLE
Allow for OmniAuth 2.0 series

### DIFF
--- a/lib/omniauth/strategies/azure_activedirectory_v2.rb
+++ b/lib/omniauth/strategies/azure_activedirectory_v2.rb
@@ -57,7 +57,7 @@ module OmniAuth
       end
 
       def callback_url
-        full_host + script_name + callback_path
+        full_host + callback_path
       end
 
       # https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens

--- a/omniauth-azure-activedirectory-v2.gemspec
+++ b/omniauth-azure-activedirectory-v2.gemspec
@@ -45,5 +45,5 @@ Gem::Specification.new do |s|
     'source_code_uri' => 'https://github.com/RIPGlobal/omniauth-azure-activedirectory-v2'
   }
 
-  s.add_runtime_dependency('omniauth-oauth2', '~> 1.7')
+  s.add_runtime_dependency('omniauth-oauth2', '~> 1.8')
 end

--- a/spec/omniauth/strategies/azure_activedirectory_v2_spec.rb
+++ b/spec/omniauth/strategies/azure_activedirectory_v2_spec.rb
@@ -356,4 +356,24 @@ RSpec.describe OmniAuth::Strategies::AzureActivedirectoryV2 do
       end
     end # "context 'with extra information in the auth token' do"
   end   # "describe 'raw_info' do"
+
+  describe 'callback_url' do
+    subject do
+      OmniAuth::Strategies::AzureActivedirectoryV2.new(app, { client_id: 'id', client_secret: 'secret', tenant_id: 'tenant' })
+    end
+
+    let(:base_url) { 'https://example.com' }
+
+    it 'has the correct default callback path' do
+      allow(subject).to receive(:full_host) { base_url }
+      allow(subject).to receive(:script_name) { '' }
+      expect(subject.callback_url).to eq(base_url + '/auth/azure_activedirectory_v2/callback')
+    end
+
+    it 'should set the callback path with script_name if present' do
+      allow(subject).to receive(:full_host) { base_url }
+      allow(subject).to receive(:script_name) { '/v1' }
+      expect(subject.callback_url).to eq(base_url + '/v1/auth/azure_activedirectory_v2/callback')
+    end
+  end
 end


### PR DESCRIPTION
* One of the breaking changes in OmniAuth 2.0+ relates to how relative URL installations are handled. See: https://github.com/omniauth/omniauth/pull/903 and https://github.com/omniauth/omniauth/wiki/Upgrading-to-2.0#relative-root-apps
* As a result, when `azure_activedirectory_v2` is used with OmniAuth 2.0+ for an app that lives at a relative URl, the `#callback_url` is incorrect (the relative URL is included twice).
* This is because OmniAuth is now prefixing the default Strategy#request_path and Strategy#callback_path with SCRIPT_NAME, but `azure_activedirectory_v2` is also adding `script_name` to `callback_url`.
* This update makes this gem compatible with OmniAuth 2.0+ but will break relative URL installatons for OmniAuth 1.x so I've also updated the gemspec to rely on a version of omniauth-oauth2 that has a dependency
  on omniauth 2.0: https://github.com/omniauth/omniauth-oauth2/pull/152#issuecomment-1159512977
* Similar change to omniauth-google-oauth2 was made here: https://github.com/zquestz/omniauth-google-oauth2/pull/403

