### PR TITLE
fix VERSION and DATE constant namespace module name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Makes compatible with OmniAuth 2 and requires it.
 
 Note: https://github.com/RIPAGlobal/omniauth-azure-activedirectory-v2/pull/6 for reasoning - Thanks @jessieay
 
-_Major version bump as no longer supports Omniauth 1._
+_Major version bump as no longer supports OmniAuth 1._
 
 ## v1.0.0 (2020-09-25)
 
@@ -21,7 +21,7 @@ Removes use of the https://graph.microsoft.com/v1.0/me API.
   - All the data provided in `info` exists in the JWT anyway, so this
     cuts down on API calls
 
-* Conforms to the Omniauth Auth Hash Schema (1.0 and later) - see:
+* Conforms to the OmniAuth Auth Hash Schema (1.0 and later) - see:
   https://github.com/omniauth/omniauth/wiki/Auth-Hash-Schema
 
   - Expose `raw_info`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Omniauth::Azure::Activedirectory::V2
+# OmniAuth::Azure::Activedirectory::V2
 
 [![Gem Version](https://badge.fury.io/rb/omniauth-azure-activedirectory-v2.svg)](https://badge.fury.io/rb/omniauth-azure-activedirectory-v2)
 [![Build Status](https://travis-ci.org/RIPGlobal/omniauth-azure-activedirectory-v2.svg)](https://travis-ci.org/RIPGlobal/omniauth-azure-activedirectory-v2)

--- a/lib/omniauth/azure_activedirectory_v2/version.rb
+++ b/lib/omniauth/azure_activedirectory_v2/version.rb
@@ -1,4 +1,4 @@
-module Omniauth
+module OmniAuth
   module Azure
     module Activedirectory
       module V2

--- a/omniauth-azure-activedirectory-v2.gemspec
+++ b/omniauth-azure-activedirectory-v2.gemspec
@@ -9,8 +9,8 @@ require 'omniauth/azure_activedirectory_v2/version'
 #
 Gem::Specification.new do |s|
   s.name                  = 'omniauth-azure-activedirectory-v2'
-  s.version               = Omniauth::Azure::Activedirectory::V2::VERSION
-  s.date                  = Omniauth::Azure::Activedirectory::V2::DATE
+  s.version               = OmniAuth::Azure::Activedirectory::V2::VERSION
+  s.date                  = OmniAuth::Azure::Activedirectory::V2::DATE
   s.summary               = 'OAuth 2 authentication with the Azure ActiveDirectory V2 API.'
   s.authors               = [ 'RIP Global'        ]
   s.email                 = [ 'dev@ripglobal.com' ]


### PR DESCRIPTION
[omniauth.gem defines `OmniAuth` module (not `Omniauth`).](https://github.com/omniauth/omniauth/blob/v2.1.0/lib/omniauth.rb#L5)

[`OmniAuth::Strategies::AzureActivedirectoryV2` is also in `OmniAuth` module.](https://github.com/RIPAGlobal/omniauth-azure-activedirectory-v2/blob/v2.0.0/lib/omniauth/strategies/azure_activedirectory_v2.rb#L3)

But `VERSION` and `DATE` constant is not in `OmniAuth` module. This pull-request fixes it.
