### PR TITLE
Fix prompt override in authorization_params

### DIFF
--- a/lib/omniauth/strategies/azure_activedirectory_v2.rb
+++ b/lib/omniauth/strategies/azure_activedirectory_v2.rb
@@ -29,7 +29,7 @@ module OmniAuth
 
         options.authorize_params = provider.authorize_params if provider.respond_to?(:authorize_params)
         options.authorize_params.domain_hint = provider.domain_hint if provider.respond_to?(:domain_hint) && provider.domain_hint
-        options.authorize_params.prompt = request.params['prompt'] if defined? request && request.params['prompt']
+        options.authorize_params.prompt = request.params['prompt'] if (defined? request) && request.params['prompt']
         options.authorize_params.scope = (provider.scope if provider.respond_to?(:scope) && provider.scope) || DEFAULT_SCOPE
 
         options.client_options.authorize_url = "#{options.base_azure_url}/#{options.tenant_id}/oauth2/v2.0/authorize"

--- a/lib/omniauth/strategies/azure_activedirectory_v2.rb
+++ b/lib/omniauth/strategies/azure_activedirectory_v2.rb
@@ -19,7 +19,7 @@ module OmniAuth
         provider = if options.tenant_provider
           options.tenant_provider.new(self)
         else
-          options # if pass has to config, get mapped right on to options
+          options
         end
 
         options.client_id = provider.client_id

--- a/lib/omniauth/strategies/azure_activedirectory_v2.rb
+++ b/lib/omniauth/strategies/azure_activedirectory_v2.rb
@@ -41,10 +41,10 @@ module OmniAuth
           options.authorize_params.prompt = request.params['prompt']
         end
 
-        if provider.respond_to?(:scope) && provider.scope
-          options.authorize_params.scope = provider.scope
+        options.authorize_params.scope = if provider.respond_to?(:scope) && provider.scope
+          provider.scope
         else
-          options.authorize_params.scope = DEFAULT_SCOPE
+          DEFAULT_SCOPE
         end
 
         options.client_options.authorize_url = "#{options.base_azure_url}/#{options.tenant_id}/oauth2/v2.0/authorize"

--- a/lib/omniauth/strategies/azure_activedirectory_v2.rb
+++ b/lib/omniauth/strategies/azure_activedirectory_v2.rb
@@ -44,9 +44,7 @@ module OmniAuth
         super
       end
 
-      uid do
-        raw_info['oid']
-      end
+      uid { raw_info['sub'] }
 
       info do
         {

--- a/lib/omniauth/strategies/azure_activedirectory_v2.rb
+++ b/lib/omniauth/strategies/azure_activedirectory_v2.rb
@@ -17,10 +17,10 @@ module OmniAuth
 
       def client
         provider = if options.tenant_provider
-                     options.tenant_provider.new(self)
-                   else
-                     options # if pass has to config, get mapped right on to options
-                   end
+          options.tenant_provider.new(self)
+        else
+          options # if pass has to config, get mapped right on to options
+        end
 
         options.client_id = provider.client_id
         options.client_secret = provider.client_secret
@@ -29,14 +29,23 @@ module OmniAuth
         options.base_azure_url =
           provider.respond_to?(:base_azure_url) ? provider.base_azure_url : BASE_AZURE_URL
 
-        options.authorize_params = provider.authorize_params if provider.respond_to?(:authorize_params)
+        if provider.respond_to?(:authorize_params)
+          options.authorize_params = provider.authorize_params
+        end
+
         if provider.respond_to?(:domain_hint) && provider.domain_hint
           options.authorize_params.domain_hint = provider.domain_hint
         end
-        options.authorize_params.prompt = request.params['prompt'] if defined?(request) && request.params['prompt']
-        options.authorize_params.scope = (if provider.respond_to?(:scope) && provider.scope
-                                            provider.scope
-                                          end) || DEFAULT_SCOPE
+
+        if defined?(request) && request.params['prompt']
+          options.authorize_params.prompt = request.params['prompt']
+        end
+
+        if provider.respond_to?(:scope) && provider.scope
+          options.authorize_params.scope = provider.scope
+        else
+          options.authorize_params.scope = DEFAULT_SCOPE
+        end
 
         options.client_options.authorize_url = "#{options.base_azure_url}/#{options.tenant_id}/oauth2/v2.0/authorize"
         options.client_options.token_url = "#{options.base_azure_url}/#{options.tenant_id}/oauth2/v2.0/token"
@@ -44,7 +53,7 @@ module OmniAuth
         super
       end
 
-      uid { raw_info['sub'] }
+      uid { raw_info['oid'] }
 
       info do
         {

--- a/lib/omniauth/strategies/azure_activedirectory_v2.rb
+++ b/lib/omniauth/strategies/azure_activedirectory_v2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'omniauth-oauth2'
 
 module OmniAuth
@@ -14,23 +16,27 @@ module OmniAuth
       args [:tenant_provider]
 
       def client
-        if options.tenant_provider
-          provider = options.tenant_provider.new(self)
-        else
-          provider = options  # if pass has to config, get mapped right on to options
-        end
+        provider = if options.tenant_provider
+                     options.tenant_provider.new(self)
+                   else
+                     options # if pass has to config, get mapped right on to options
+                   end
 
         options.client_id = provider.client_id
         options.client_secret = provider.client_secret
         options.tenant_id =
-            provider.respond_to?(:tenant_id) ? provider.tenant_id : 'common'
+          provider.respond_to?(:tenant_id) ? provider.tenant_id : 'common'
         options.base_azure_url =
-            provider.respond_to?(:base_azure_url) ? provider.base_azure_url : BASE_AZURE_URL
+          provider.respond_to?(:base_azure_url) ? provider.base_azure_url : BASE_AZURE_URL
 
         options.authorize_params = provider.authorize_params if provider.respond_to?(:authorize_params)
-        options.authorize_params.domain_hint = provider.domain_hint if provider.respond_to?(:domain_hint) && provider.domain_hint
-        options.authorize_params.prompt = request.params['prompt'] if (defined? request) && request.params['prompt']
-        options.authorize_params.scope = (provider.scope if provider.respond_to?(:scope) && provider.scope) || DEFAULT_SCOPE
+        if provider.respond_to?(:domain_hint) && provider.domain_hint
+          options.authorize_params.domain_hint = provider.domain_hint
+        end
+        options.authorize_params.prompt = request.params['prompt'] if defined?(request) && request.params['prompt']
+        options.authorize_params.scope = (if provider.respond_to?(:scope) && provider.scope
+                                            provider.scope
+                                          end) || DEFAULT_SCOPE
 
         options.client_options.authorize_url = "#{options.base_azure_url}/#{options.tenant_id}/oauth2/v2.0/authorize"
         options.client_options.token_url = "#{options.base_azure_url}/#{options.tenant_id}/oauth2/v2.0/token"
@@ -38,17 +44,17 @@ module OmniAuth
         super
       end
 
-      uid {
+      uid do
         raw_info['oid']
-      }
+      end
 
       info do
         {
-            name: raw_info['name'],
-            email: raw_info['email'] || raw_info['upn'],
-            nickname: raw_info['unique_name'],
-            first_name: raw_info['given_name'],
-            last_name: raw_info['family_name']
+          name: raw_info['name'],
+          email: raw_info['email'] || raw_info['upn'],
+          nickname: raw_info['unique_name'],
+          first_name: raw_info['given_name'],
+          last_name: raw_info['family_name']
         }
       end
 
@@ -72,8 +78,16 @@ module OmniAuth
       #
       def raw_info
         if @raw_info.nil?
-          id_token_data   = ::JWT.decode(access_token.params['id_token'], nil, false).first rescue {}
-          auth_token_data = ::JWT.decode(access_token.token,              nil, false).first rescue {}
+          id_token_data = begin
+            ::JWT.decode(access_token.params['id_token'], nil, false).first
+          rescue StandardError
+            {}
+          end
+          auth_token_data = begin
+            ::JWT.decode(access_token.token, nil, false).first
+          rescue StandardError
+            {}
+          end
 
           id_token_data.merge!(auth_token_data)
           @raw_info = id_token_data
@@ -81,7 +95,6 @@ module OmniAuth
 
         @raw_info
       end
-
     end
   end
 end

--- a/spec/omniauth/strategies/azure_activedirectory_v2_spec.rb
+++ b/spec/omniauth/strategies/azure_activedirectory_v2_spec.rb
@@ -40,12 +40,27 @@ RSpec.describe OmniAuth::Strategies::AzureActivedirectoryV2 do
         expect(subject.client.options[:token_url]).to eql('https://login.microsoftonline.com/tenant/oauth2/v2.0/token')
       end
 
+      it 'supports authorization_params' do
+        @options = { authorize_params: {prompt: 'select_account'} }
+        allow(subject).to receive(:request) { request }
+        subject.client
+        expect(subject.authorize_params[:prompt]).to eql('select_account')
+      end
+
       describe "overrides" do
         it 'should override domain_hint' do
           @options = {domain_hint: 'hint'}
           allow(subject).to receive(:request) { request }
           subject.client
           expect(subject.authorize_params[:domain_hint]).to eql('hint')
+        end
+
+        it 'overrides prompt via query parameter' do
+          @options = { authorize_params: {prompt: 'select_account'} }
+          override_request = double('Request', :params => {'prompt'.to_s => 'consent'}, :cookies => {}, :env => {})
+          allow(subject).to receive(:request) { override_request }
+          subject.client
+          expect(subject.authorize_params[:prompt]).to eql('consent')
         end
       end
     end


### PR DESCRIPTION
Without the parentheses, the if statement would always return true since the boolean is evaluated first and is always defined.

Note: the request param .to_s matches what happens in real-life and is also how the google oauth2 gem test.
https://github.com/zquestz/omniauth-google-oauth2/blob/master/spec/omniauth/strategies/google_oauth2_spec.rb#L243