### PR TITLE
Add newer Ruby versions to Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,7 @@ language: ruby
 cache: bundler
 rvm:
   - 2.7.0
-before_install: gem install bundler -v 2.1.2
+  - 3.0.6
+  - 3.1.4
+  - 3.2.2
+before_install: gem install bundler


### PR DESCRIPTION
* These versions have been out for a while
* https://www.ruby-lang.org/en/downloads/releases/