### PR TITLE
Enable scope overrides from request params

### DIFF
--- a/lib/omniauth/strategies/azure_activedirectory_v2.rb
+++ b/lib/omniauth/strategies/azure_activedirectory_v2.rb
@@ -41,7 +41,9 @@ module OmniAuth
           options.authorize_params.prompt = request.params['prompt']
         end
 
-        options.authorize_params.scope = if provider.respond_to?(:scope) && provider.scope
+        options.authorize_params.scope = if defined?(request) && request.params['scope']
+          request.params['scope']
+        elsif provider.respond_to?(:scope) && provider.scope
           provider.scope
         else
           DEFAULT_SCOPE

--- a/spec/omniauth/strategies/azure_activedirectory_v2_spec.rb
+++ b/spec/omniauth/strategies/azure_activedirectory_v2_spec.rb
@@ -299,6 +299,12 @@ RSpec.describe OmniAuth::Strategies::AzureActivedirectoryV2 do
       it 'has correct token url' do
         expect(subject.client.options[:token_url]).to eql('https://login.microsoftonline.com/common/oauth2/v2.0/token')
       end
+
+      it 'has correct scope from request params' do
+        request.params['scope'] = 'openid email offline_access Calendars.Read'
+        subject.client
+        expect(subject.authorize_params[:scope]).to eql('openid email offline_access Calendars.Read')
+      end
     end
   end
 


### PR DESCRIPTION
Hello hello,

I ran into a problem trying to override the `scope` parameter in the OAuth URL. This PR fixes that so you can call e.g. `azure_oauth_path scope: "openid email Calendars.Read"` without having to define it in the config.

Also added a little spec, any questions/issues let me know!