### PR TITLE
CI integration and general maintenance

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,7 +12,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby: ['3.0', '3.1', '3.2', '3.3']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,28 @@
+name: Ruby
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Ruby ${{ matrix.ruby }}
+    strategy:
+      matrix:
+        ruby: ['3.0', '3.1', '3.2', '3.3']
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+        rubygems: 3.5.11
+
+    - name: Run tests
+      run: bundle exec rspec --backtrace

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,7 +12,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        ruby: ['3.0', '3.1', '3.2', '3.3']
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3']
 
     steps:
     - uses: actions/checkout@v3

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: ruby
 cache: bundler
 rvm:
-  - 3.1.5
+  - 3.1.6
   - 3.2.4
-  - 3.3.1
+  - 3.3.3
 before_install: gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
----
-language: ruby
-cache: bundler
-rvm:
-  - 3.1.6
-  - 3.2.4
-  - 3.3.3
-before_install: gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in omniauth-azure-activedirectory-v2.gemspec
+#
 gemspec
-
-gem "rake", "~> 12.0"
-gem "rspec", "~> 3.0"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # OmniAuth::Azure::Activedirectory::V2
 
-[![Gem Version](https://badge.fury.io/rb/omniauth-azure-activedirectory-v2.svg)](https://badge.fury.io/rb/omniauth-azure-activedirectory-v2)
-[![Build Status](https://app.travis-ci.com/RIPAGlobal/omniauth-azure-activedirectory-v2.svg?branch=master)](https://app.travis-ci.com/github/RIPAGlobal/omniauth-azure-activedirectory-v2)
-[![License](https://img.shields.io/github/license/RIPAGlobal/omniauth-azure-activedirectory-v2.svg)](LICENSE.md)
+[![Gem Version](https://badge.fury.io/rb/omniauth-azure-activedirectory-v2.svg)](https://rubygems.org/gems/omniauth-azure-activedirectory-v2)
+[![Build Status](https://github.com/RIPAGlobal/omniauth-azure-activedirectory-v2/actions/workflows/master.yml/badge.svg)](https://github.com/RIPAGlobal/omniauth-azure-activedirectory-v2/actions)
+[![License](https://img.shields.io/github/license/RIPAGlobal/omniauth-azure-activedirectory-v2.svg)](LICENSE.txt)
 
 OAuth 2 authentication with [Azure ActiveDirectory's V2 API](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-overview). Rationale:
 

--- a/omniauth-azure-activedirectory-v2.gemspec
+++ b/omniauth-azure-activedirectory-v2.gemspec
@@ -46,4 +46,7 @@ Gem::Specification.new do |s|
   }
 
   s.add_runtime_dependency('omniauth-oauth2', '~> 1.8')
+
+  s.add_development_dependency('rake',  '~> 13.2 ')
+  s.add_development_dependency('rspec', '~>  3.13')
 end


### PR DESCRIPTION
* Bump Ruby patch versions following #25 (thanks to @frenkel).
* Switch to GitHub Actions to reduce third party service dependencies and remove need to track Ruby patch versions.
* Update `README.md` accordingly
* `Gemfile` vs `.gemspec` maintenance shuffle to move development mode gems to the latter