### PR TITLE
33 improve id token extraction and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,15 @@ $ gem install omniauth-azure-activedirectory-v2
 
 Please start by reading https://github.com/marknadig/omniauth-azure-oauth2 for basic configuration and background information. Note that with this gem, you must use strategy name `azure_activedirectory_v2` rather than `azure_oauth2`. Additional configuration information is given below.
 
-### Configuration
+### Entra ID Configuration
+In most cases, you only want to receive 'verified' email addresses in
+your application. For older app registrations in the Azure portal,
+this may need to be [enabled explicitly](https://learn.microsoft.com/en-us/graph/applications-authenticationbehaviors?tabs=http#prevent-the-issuance-of-email-claims-with-unverified-domain-owners).
+
+It's [enabled by default](https://learn.microsoft.com/en-us/entra/identity-platform/migrate-off-email-claim-authorization#how-do-i-protect-my-application-immediately)
+for new multi-tenant app registrations made after June 2023.
+
+### Implementation
 
 #### With `OmniAuth::Builder`
 

--- a/lib/omniauth/strategies/azure_activedirectory_v2.rb
+++ b/lib/omniauth/strategies/azure_activedirectory_v2.rb
@@ -9,6 +9,8 @@ module OmniAuth
 
       option :name, 'azure_activedirectory_v2'
       option :tenant_provider, nil
+      option :jwt_leeway, 60
+
 
       DEFAULT_SCOPE = 'openid profile email'
 
@@ -64,12 +66,17 @@ module OmniAuth
         super
       end
 
-      uid { raw_info['oid'] }
+      uid do
+        # as instructed by https://learn.microsoft.com/en-us/entra/identity-platform/migrate-off-email-claim-authorization
+        raw_info['tid'] + raw_info['oid']
+        # Alternative would be to use 'sub' but this is only unique in client/app registration context. If a different
+        # app registration is used, the 'sub' values can be different
+      end
 
       info do
         {
           name: raw_info['name'],
-          email: raw_info['email'] || raw_info['upn'],
+          email: raw_info['email'],
           nickname: raw_info['unique_name'],
           first_name: raw_info['given_name'],
           last_name: raw_info['family_name']
@@ -101,6 +108,22 @@ module OmniAuth
           rescue StandardError
             {}
           end
+
+          # For multi-tenant apps ('common' tenant_id) it doesn't make any sense to verify the token issuer, because the
+          # value of 'iss' in the token depends on the 'tid' in the token itself
+          issuer = options.tenant_id.nil? ? nil : "#{options.base_azure_url}/#{options.tenant_id}/v2.0"
+
+          # https://learn.microsoft.com/en-us/entra/identity-platform/id-tokens#validate-tokens
+          JWT::Verify.verify_claims(
+            id_token_data,
+            verify_iss: !issuer.nil?,
+            iss: issuer,
+            verify_aud: true,
+            aud: options.client_id,
+            verify_expiration: true,
+            verify_not_before: true,
+            leeway: options[:jwt_leeway]
+          )
           auth_token_data = begin
             ::JWT.decode(access_token.token, nil, false).first
           rescue StandardError


### PR DESCRIPTION
Possible solution to solve #33 

It:
1. Uses 'tid' + 'oid' for the UUID, since the 'oid' claim used before was not guaranteed to be unique accross tenants
2. Only uses the 'email' claim to derive the email of the user, since, with the correct Entra ID settings, this should contain only verified email addresses
3. Adds claim validation
4. Adds a part to the docs about configuring the entra-id app to only give out verified email addresses

Notes/Questions:
1. Currently the 'access_token' contents are merged with the id_token contents. Do we know if this was exclusively used to derive the 'upn' in the past? In that case, this part should be removed.
2. It seems like there's a seperate token URL for 'custom_policies'. I'm assuming (I can't find anything conflicting this in the docs), that the 'url' in the 'iss' claim never includes the custom policy part.
3. The 'iss' is not validated if a multi-tenant app is used, since the 'iss' will be different depending on the organization the user logs in to.

Note that this should still be operationally tested with both single-tenant and multi-tenant applications