### PR TITLE
Bump version to 2.4.0 for deprecation warning addition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ Gemfile.lock
 
 # built gems
 *.gem
+
+# macOS metadata
+.DS_Store
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v2.4.0 (2024-10-17)
+
+Deprecation warnings for end-of-life of the gem under this name. No other changes. The GitHub repository is to be renamed and the gem released (starting at major version 3) as `omniauth-entra-id`, with some breaking changes but details of how to update will be provided in the new gem via an `UPGRADING.md` document.
+
 ## v2.3.0 (2024-07-16)
 
 [Implements](https://github.com/RIPAGlobal/omniauth-azure-activedirectory-v2/pull/29) support for on-premise Active Directory installations via the `adfs` option; see `README.md` for details - thanks @frenkel!

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://github.com/RIPAGlobal/omniauth-azure-activedirectory-v2/actions/workflows/master.yml/badge.svg)](https://github.com/RIPAGlobal/omniauth-azure-activedirectory-v2/actions)
 [![License](https://img.shields.io/github/license/RIPAGlobal/omniauth-azure-activedirectory-v2.svg)](LICENSE.txt)
 
-**IMPORTANT: V2 is EOL** and has been replaced by V3, which is also a renamed gem, since Microsoft in their "wisdom" renamed Azure AD to Entra ID and a gem using the old name will become increasingly hard for people to 'discover'. The major version bump provides an opportunity to fix a few things with breaking changes, too. Please switch to `omniauth-entra-id`.
+**IMPORTANT: V2 is end-of-life** and superseded by a renamed gem, since Microsoft in their "wisdom" renamed Azure AD to Entra ID. A gem using the old name will become increasingly hard for people to 'discover'. The major version bump provides an opportunity to fix a few things via breaking changes, too. Please switch to `omniauth-entra-id`.
 
 OAuth 2 authentication with [Azure ActiveDirectory's V2 API](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-overview). Rationale:
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Build Status](https://github.com/RIPAGlobal/omniauth-azure-activedirectory-v2/actions/workflows/master.yml/badge.svg)](https://github.com/RIPAGlobal/omniauth-azure-activedirectory-v2/actions)
 [![License](https://img.shields.io/github/license/RIPAGlobal/omniauth-azure-activedirectory-v2.svg)](LICENSE.txt)
 
+**IMPORTANT: V2 is EOL** and has been replaced by V3, which is also a renamed gem, since Microsoft in their "wisdom" renamed Azure AD to Entra ID and a gem using the old name will become increasingly hard for people to 'discover'. The major version bump provides an opportunity to fix a few things with breaking changes, too. Please switch to `omniauth-entra-id`.
+
 OAuth 2 authentication with [Azure ActiveDirectory's V2 API](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-overview). Rationale:
 
 * https://github.com/marknadig/omniauth-azure-oauth2 is no longer maintained.

--- a/lib/omniauth/azure_activedirectory_v2.rb
+++ b/lib/omniauth/azure_activedirectory_v2.rb
@@ -1,2 +1,4 @@
+warn "[DEPRECATION] This gem has been renamed to 'omniauth-entra-id' and will no longer be supported. Please switch to 'omniauth-entra-id' as soon as possible."
+
 require File.join('omniauth', 'azure_activedirectory_v2', 'version')
 require File.join('omniauth', 'strategies', 'azure_activedirectory_v2')

--- a/lib/omniauth/azure_activedirectory_v2/version.rb
+++ b/lib/omniauth/azure_activedirectory_v2/version.rb
@@ -2,8 +2,8 @@ module OmniAuth
   module Azure
     module Activedirectory
       module V2
-        VERSION = "2.3.0"
-        DATE    = "2024-07-16"
+        VERSION = "2.4.0"
+        DATE    = "2024-10-17"
       end
     end
   end

--- a/omniauth-azure-activedirectory-v2.gemspec
+++ b/omniauth-azure-activedirectory-v2.gemspec
@@ -8,6 +8,14 @@ require 'omniauth/azure_activedirectory_v2/version'
 # https://guides.rubygems.org/specification-reference/
 #
 Gem::Specification.new do |s|
+  s.post_install_message = <<-MESSAGE
+  !    The 'omniauth-azure-activedirectory-v2' gem has been deprecated and is
+  !    replaced by 'omniauth-entra-id'.
+  !
+  !    See: https://rubygems.org/gems/omniauth-entra-id
+  !    And: https://github.com/RIPAGlobal/omniauth-entra-id
+  MESSAGE
+
   s.name                  = 'omniauth-azure-activedirectory-v2'
   s.version               = OmniAuth::Azure::Activedirectory::V2::VERSION
   s.date                  = OmniAuth::Azure::Activedirectory::V2::DATE


### PR DESCRIPTION
Gem is to be renamed to account for Microsoft's rename of Azure AD to Entra ID, with some breaking changes.